### PR TITLE
Create crypto price service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,9 +30,9 @@ gem "bootsnap", require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 # gem "rack-cors"
 
-gem 'rswag-api'
-gem 'rswag-ui'
-gem 'rswag-specs'
+gem "rswag-api"
+gem "rswag-ui"
+gem "rswag-specs"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
@@ -46,4 +46,5 @@ group :development, :test do
 
   # Tests
   gem "rspec-rails", "~> 7.1", ">= 7.1.1"
+  gem 'webmock', '~> 3.25'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,9 @@ GEM
     builder (3.3.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     crass (1.0.6)
     date (3.4.1)
     debug (1.10.0)
@@ -95,6 +98,7 @@ GEM
     erubi (1.13.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashdiff (1.1.2)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.0)
@@ -194,6 +198,7 @@ GEM
     regexp_parser (2.10.0)
     reline (0.6.0)
       io-console (~> 0.5)
+    rexml (3.4.1)
     rspec-core (3.13.3)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
@@ -263,6 +268,10 @@ GEM
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
     useragent (0.16.11)
+    webmock (3.25.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.7)
       base64
       websocket-extensions (>= 0.1.0)
@@ -286,6 +295,7 @@ DEPENDENCIES
   rswag-ui
   rubocop-rails-omakase
   tzinfo-data
+  webmock (~> 3.25)
 
 RUBY VERSION
    ruby 3.2.0p0

--- a/app/controllers/prices_controller.rb
+++ b/app/controllers/prices_controller.rb
@@ -1,0 +1,17 @@
+class PricesController < ActionController::Base
+  # Coin ids can be changed to be received by params according to requirements. Now is static because it is the only one required
+  DEFAULT_COIN_ID = "bitcoin"
+
+  def index
+    result = CryptoPriceService.call(coin_ids: [ DEFAULT_COIN_ID ])
+
+    if result.success?
+      render json: result.data, status: :ok
+    else
+      render json: {
+        error:  result.error_message,
+        code:   result.error_code
+      }, status: result.http_status
+    end
+  end
+end

--- a/app/services/crypto_price_service.rb
+++ b/app/services/crypto_price_service.rb
@@ -1,0 +1,113 @@
+require "net/http"
+require "uri"
+require "json"
+
+class CryptoPriceService
+  # Values could be changed based on the requirements
+  ALLOWED_COINS = ["bitcoin"].freeze
+  ALLOWED_CURRENCIES = ["usd"].freeze
+  DEFAULT_PRECISION = 2
+
+  def initialize(coin_ids:, vs_currency: "usd")
+    @coin_ids = filter_coin_ids(coin_ids)
+    @vs_currency = vs_currency
+  end
+
+  def self.call(coin_ids:, vs_currency: "usd")
+    new(coin_ids:, vs_currency:).call
+  end
+
+  def call
+    validate_values
+    req_params = build_request
+    response = make_request(req_params)
+
+    handle_response(response)
+  end
+
+  private
+
+  def filter_coin_ids(input_coin_ids)
+    input_coin_ids & ALLOWED_COINS
+  end
+
+  def validate_values
+    raise ArgumentError, "No valid Coin IDs provided" if @coin_ids.empty?
+    raise ArgumentError, "Invalid currency" unless ALLOWED_CURRENCIES.include?(@vs_currency)
+  end
+
+  def build_request
+    base_url = ENV["COIN_GECKO_API_URL"]
+    api_key  = ENV["COIN_GECKO_API_KEY"]
+
+    endpoint = "#{base_url}/simple/price?ids=#{merge_coin_ids}" \
+               "&vs_currencies=#{@vs_currency}&precision=#{DEFAULT_PRECISION}"
+
+    uri = URI(endpoint)
+
+    request = Net::HTTP::Get.new(uri)
+    request["Accept"] = "application/json"
+    request["x_cg_demo_api_key"] = api_key if api_key
+
+    { uri: uri, request: request }
+  end
+
+  def make_request(params)
+    uri     = params[:uri]
+    request = params[:request]
+    timeout = ENV["DEFAULT_TIMEOUT"].to_i
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = (uri.scheme == "https")
+    http.open_timeout = timeout
+    http.read_timeout = timeout
+
+    begin
+      http.request(request)
+    rescue SocketError, Timeout::Error, Errno::ECONNREFUSED => e
+      # Handle network errors
+      error_message = I18n.t("coingecko_errors.503", default: I18n.t("coingecko_errors.default"))
+      ServiceResult.new(
+        success: false,
+        error_message: "#{error_message} (#{e.message})",
+        error_code: 503,
+        http_status: 503
+      )
+    end
+  end
+
+  def handle_response(response)
+    # Handle non-HTTP response
+    return response unless response.is_a?(Net::HTTPResponse)
+
+    code = response.code.to_i
+
+    if code == 200
+      begin
+        data = JSON.parse(response.body)
+        return ServiceResult.new(success: true, data: data, http_status: 200)
+      rescue JSON::ParserError => e
+        # Handle invalid JSON response
+        ServiceResult.new(
+          success: false,
+          error_message: "Invalid JSON response",
+          error_code: 500,
+          http_status: 500
+        )
+      end
+    end
+
+    # Handle coin gecko errors
+    error_message = I18n.t("coingecko_errors.#{code}", default: I18n.t("coingecko_errors.default"))
+    ServiceResult.new(
+      success: false,
+      error_message: error_message,
+      error_code: code,
+      http_status: code
+    )
+  end
+
+  def merge_coin_ids
+    @coin_ids.join(",")
+  end
+end

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,5 +1,4 @@
 Rswag::Api.configure do |c|
-
   # Specify a root folder where Swagger JSON files are located
   # This is used by the Swagger middleware to serve requests for API descriptions
   # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
@@ -10,5 +9,5 @@ Rswag::Api.configure do |c|
   # The function will have access to the rack env for the current request
   # For example, you could leverage this to dynamically assign the "host" property
   #
-  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+  # c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
 end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,5 +1,4 @@
 Rswag::Ui.configure do |c|
-
   # List the Swagger endpoints that you want to be documented through the
   # swagger-ui. The first parameter is the path (absolute or relative to the UI
   # host) to the corresponding endpoint and the second is a title that will be

--- a/config/locales/coingecko_errors.yml
+++ b/config/locales/coingecko_errors.yml
@@ -1,12 +1,13 @@
 # Errors code from documentation https://docs.coingecko.com/reference/common-errors-rate-limit
-coingecko_errors: &errors
-  400: "Invalid request: The server could not process your request."
-  401: "Unauthorized: Invalid authentication credentials."
-  403: "Forbidden: Access blocked by server."
-  429: "Rate limit exceeded: Please reduce API calls or upgrade your plan."
-  500: "Internal Server Error: The server encountered an unexpected issue."
-  503: "Service Unavailable."
-  1020: "Access Denied: CDN firewall rule violation."
-  10002: "API Key Missing: Invalid API key credentials."
-  10005: "Access Restricted: This endpoint requires a Pro API subscription."
-  default: "An unexpected error occurred."
+en:
+  coingecko_errors: &errors
+    400: "Invalid request: The server could not process your request."
+    401: "Unauthorized: Invalid authentication credentials."
+    403: "Forbidden: Access blocked by server."
+    429: "Rate limit exceeded: Please reduce API calls or upgrade your plan."
+    500: "Internal Server Error: The server encountered an unexpected issue."
+    503: "Service Unavailable."
+    1020: "Access Denied: CDN firewall rule violation."
+    10002: "API Key Missing: Invalid API key credentials."
+    10005: "Access Restricted: This endpoint requires a Pro API subscription."
+    default: "An unexpected error occurred."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,5 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
-  # Defines the root path route ("/")
-  # root "posts#index"
+  resources :prices, only: [ :index ]
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,17 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.2].define(version: 0) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end

--- a/spec/controllers/prices_controller_spec.rb
+++ b/spec/controllers/prices_controller_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe PricesController, type: :controller do
+  let(:coin_ids) { [ 'bitcoin' ] }
+  let(:default_price) { 50000.00 }
+  describe 'GET #index' do
+    context 'when the service returns a successful response' do
+      let(:service_response) do
+        instance_double('ServiceResult', success?: true, data: { 'bitcoin' => { 'usd' => default_price } }, http_status: 200)
+      end
+
+      before do
+        allow(CryptoPriceService).to receive(:call).with(coin_ids: coin_ids).and_return(service_response)
+        get :index
+      end
+
+      it 'returns status 200' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'renders the correct JSON response' do
+        json_response = JSON.parse(response.body)
+        expect(json_response).to eq({ 'bitcoin' => { 'usd' => default_price } })
+      end
+    end
+
+    context 'when the service returns an error' do
+      let(:service_response) do
+        instance_double('ServiceResult', success?: false, error_message: 'Service Unavailable', error_code: 503, http_status: 503)
+      end
+
+      before do
+        allow(CryptoPriceService).to receive(:call).with(coin_ids: coin_ids).and_return(service_response)
+        get :index
+      end
+
+      it 'returns status 503' do
+        expect(response).to have_http_status(:service_unavailable)
+      end
+
+      it 'renders the correct error message' do
+        json_response = JSON.parse(response.body)
+        expect(json_response['error']).to eq('Service Unavailable')
+        expect(json_response['code']).to eq(503)
+      end
+    end
+
+    context 'when the service returns an invalid JSON error' do
+      let(:service_response) do
+        instance_double('ServiceResult', success?: false, error_message: 'Invalid JSON response', error_code: 500, http_status: 500)
+      end
+
+      before do
+        allow(CryptoPriceService).to receive(:call).with(coin_ids: coin_ids).and_return(service_response)
+        get :index
+      end
+
+      it 'returns status 500' do
+        expect(response).to have_http_status(:internal_server_error)
+      end
+
+      it 'renders the correct error message' do
+        json_response = JSON.parse(response.body)
+        expect(json_response['error']).to eq('Invalid JSON response')
+        expect(json_response['code']).to eq(500)
+      end
+    end
+  end
+end

--- a/spec/integration/prices_spec.rb
+++ b/spec/integration/prices_spec.rb
@@ -1,0 +1,47 @@
+require 'swagger_helper'
+
+RSpec.describe 'Prices API', type: :request, swagger_doc: 'v1/swagger.yaml' do
+  path '/prices' do
+    get 'Get crypto prices (only BTC for the moment)' do
+      tags 'Prices'
+      produces 'application/json'
+
+      response '200', 'Prices returned' do
+        schema type: :object,
+          properties: {
+            bitcoin: {
+              type: :object,
+              properties: {
+                usd: { type: :number }
+              }
+            }
+          },
+          required: [ 'bitcoin' ]
+
+        run_test!
+      end
+
+      response '503', 'Service Unavailable' do
+        schema type: :object,
+          properties: {
+            error: { type: :string },
+            code: { type: :integer }
+          },
+          required: [ 'error', 'code' ]
+
+        run_test!
+      end
+
+      response '500', 'Internal Server Error' do
+        schema type: :object,
+          properties: {
+            error: { type: :string },
+            code: { type: :integer }
+          },
+          required: [ 'error', 'code' ]
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
+require 'webmock/rspec'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production

--- a/spec/services/crypto_price_service_spec.rb
+++ b/spec/services/crypto_price_service_spec.rb
@@ -1,0 +1,134 @@
+require 'rails_helper'
+require 'net/http'
+
+RSpec.describe CryptoPriceService, type: :service do
+  let(:coin_ids) { [ 'bitcoin' ] }
+  let(:vs_currency) { 'usd' }
+  let(:api_url) { 'https://api.coingecko.com/api/v3' }
+  let(:api_key) { 'some_api_key' }
+
+  before do
+    stub_const('ENV', {
+      'COIN_GECKO_API_URL' => api_url,
+      'COIN_GECKO_API_KEY' => api_key,
+      'DEFAULT_TIMEOUT' => '30'
+    })
+  end
+
+  describe '#call' do
+    context 'with valid parameters' do
+      context 'when API request is successful' do
+        let(:mock_response) do
+          instance_double(
+            Net::HTTPOK,
+            code: '200',
+            body: { 'bitcoin' => { 'usd' => 50000.00 } }.to_json
+          )
+        end
+
+        before do
+          stub_request(:get, "#{api_url}/simple/price?ids=bitcoin&vs_currencies=usd&precision=2")
+            .to_return(status: 200, body: mock_response.body)
+        end
+
+        it 'returns successful service result with parsed data' do
+          result = described_class.call(coin_ids: coin_ids)
+          expect(result).to be_success
+          expect(result.data).to eq({
+            'bitcoin' => { 'usd' => 50000.00 },
+          })
+          expect(result.http_status).to eq(200)
+        end
+      end
+
+      context 'when API returns an error' do
+        it 'returns error service result with coingecko default error' do
+          stub_request(:get, /#{api_url}/).to_return(status: 402, body: '{}')
+          result = described_class.call(coin_ids: coin_ids)
+
+          expect(result).not_to be_success
+          expect(result.error_code).to eq(402)
+          expect(result.error_message).to include('unexpected error')
+        end
+
+        it 'returns error service result with coingecko invalid request error' do
+            stub_request(:get, /#{api_url}/).to_return(status: 400, body: '{}')
+            result = described_class.call(coin_ids: coin_ids)
+
+            expect(result).not_to be_success
+            expect(result.error_code).to eq(400)
+            expect(result.error_message).to include('Invalid request')
+          end
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'raises error for empty coin_ids' do
+        expect {
+          described_class.call(coin_ids: [])
+        }.to raise_error(ArgumentError, 'No valid Coin IDs provided')
+      end
+
+      it 'raises error for not allowed coin_ids' do
+        expect {
+          described_class.call(coin_ids: [ 'ethereum', 'dogecoin' ])
+        }.to raise_error(ArgumentError, 'No valid Coin IDs provided')
+      end
+
+      it 'raises error for invalid currency' do
+        expect {
+          described_class.call(coin_ids: coin_ids, vs_currency: 'eur')
+        }.to raise_error(ArgumentError, 'Invalid currency')
+      end
+    end
+
+    context 'when network errors occur' do
+      before do
+        allow_any_instance_of(Net::HTTP).to receive(:request).and_raise(Timeout::Error)
+      end
+
+      it 'handles timeout errors gracefully' do
+        result = described_class.call(coin_ids: coin_ids, vs_currency: 'usd')
+
+        expect(result).not_to be_success
+        expect(result.error_code).to eq(503)
+        expect(result.error_message).to include('Service Unavailable')
+      end
+    end
+
+    context 'when using API key' do
+      it 'includes API key in headers when present' do
+        req = described_class.new(coin_ids: coin_ids).send(:build_request)
+
+        expect(req[:request]['x_cg_demo_api_key']).to eq(api_key)
+      end
+
+      it 'does not include API key when not present' do
+        ENV['COIN_GECKO_API_KEY'] = nil
+        req = described_class.new(coin_ids: coin_ids).send(:build_request)
+
+        expect(req[:request]['x_cg_demo_api_key']).to be_nil
+      end
+    end
+  end
+
+  describe '#build_request' do
+    it 'constructs correct URI with multiple coin IDs' do
+      service = described_class.new(coin_ids: [ 'bitcoin' ])
+      uri = service.send(:build_request)[:uri]
+
+      expect(uri.query).to include('ids=bitcoin')
+      expect(uri.query).to include('vs_currencies=usd')
+      expect(uri.query).to include('precision=2')
+    end
+  end
+
+  describe '#merge_coin_ids' do
+    it 'joins coin IDs with commas' do
+      service = described_class.new(coin_ids: [ 'bitcoin' ])
+      result = service.send(:merge_coin_ids)
+
+      expect(result).to eq('bitcoin')
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -23,14 +23,8 @@ RSpec.configure do |config|
       },
       paths: {},
       servers: [
-        {
-          url: 'https://{defaultHost}',
-          variables: {
-            defaultHost: {
-              default: 'www.example.com'
-            }
-          }
-        }
+        { url: 'http://localhost:3000' },
+        { url: 'https://mr-peanutbutter-app-35d05975bacd.herokuapp.com/' }
       ]
     }
   }

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,57 @@
+---
+openapi: 3.0.1
+info:
+  title: API V1
+  version: v1
+paths:
+  "/prices":
+    get:
+      summary: Get crypto prices (only BTC for the moment)
+      tags:
+      - Prices
+      responses:
+        '200':
+          description: Prices returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  bitcoin:
+                    type: object
+                    properties:
+                      usd:
+                        type: number
+                required:
+                - bitcoin
+        '503':
+          description: Service Unavailable
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: integer
+                required:
+                - error
+                - code
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: integer
+                required:
+                - error
+                - code
+servers:
+- url: http://localhost:3000
+- url: https://mr-peanutbutter-app-35d05975bacd.herokuapp.com/


### PR DESCRIPTION
### Changelog

This includes a new service to make request to [Coingecko API](https://docs.coingecko.com/) to fetch current price.

- Added `coingecko_errors.yml` with common errors from it's [docs](https://docs.coingecko.com/reference/common-errors-rate-limit)


### New dependencies
- Added a new gem `webmock` to stub requests when testing