### PR TITLE
Create user and token structure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,9 +30,18 @@ gem "bootsnap", require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 # gem "rack-cors"
 
+# Documentation
 gem "rswag-api"
 gem "rswag-ui"
 gem "rswag-specs"
+
+# Authentication
+gem "devise", '~> 4.9', ">= 4.9.4"
+gem "devise_token_auth", "~> 1.2", ">= 1.2.5"
+gem "omniauth", "~> 2.1", ">= 2.1.2"
+
+# Serializer
+gem "active_model_serializers", "~> 0.10.15"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
@@ -47,4 +56,7 @@ group :development, :test do
   # Tests
   gem "rspec-rails", "~> 7.1", ">= 7.1.1"
   gem 'webmock', '~> 3.25'
+  gem "factory_bot_rails", "~> 6.4", ">= 6.4.4"
+  gem "faker", "~> 3.5", ">= 3.5.1"
+  gem "shoulda-matchers", "~> 6.4"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,11 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_model_serializers (0.10.15)
+      actionpack (>= 4.1)
+      activemodel (>= 4.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (7.2.2.1)
       activesupport (= 7.2.2.1)
       globalid (>= 0.3.6)
@@ -76,6 +81,7 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
     base64 (0.2.0)
+    bcrypt (3.1.20)
     benchmark (0.4.0)
     bigdecimal (3.1.9)
     bootsnap (1.18.4)
@@ -83,6 +89,8 @@ GEM
     brakeman (7.0.0)
       racc
     builder (3.3.0)
+    case_transform (0.2)
+      activesupport
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crack (1.0.0)
@@ -93,12 +101,30 @@ GEM
     debug (1.10.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    devise (4.9.4)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
+    devise_token_auth (1.2.5)
+      bcrypt (~> 3.0)
+      devise (> 3.5.2, < 5)
+      rails (>= 4.2.0, < 8.1)
     diff-lcs (1.6.0)
     drb (2.2.1)
     erubi (1.13.1)
+    factory_bot (6.5.1)
+      activesupport (>= 6.1.0)
+    factory_bot_rails (6.4.4)
+      factory_bot (~> 6.5)
+      railties (>= 5.0.0)
+    faker (3.5.1)
+      i18n (>= 1.8.11, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashdiff (1.1.2)
+    hashie (5.0.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.0)
@@ -110,6 +136,7 @@ GEM
     json-schema (5.1.1)
       addressable (~> 2.8)
       bigdecimal (~> 3.1)
+    jsonapi-renderer (0.2.2)
     language_server-protocol (3.17.0.4)
     logger (1.6.6)
     loofah (2.24.0)
@@ -138,6 +165,11 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.2-x86_64-linux-gnu)
       racc (~> 1.4)
+    omniauth (2.1.2)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    orm_adapter (0.5.0)
     parallel (1.26.3)
     parser (3.3.7.1)
       ast (~> 2.4.1)
@@ -155,6 +187,10 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.10)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
     rack-session (2.1.0)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -198,6 +234,9 @@ GEM
     regexp_parser (2.10.0)
     reline (0.6.0)
       io-console (~> 0.5)
+    responders (3.1.1)
+      actionpack (>= 5.2)
+      railties (>= 5.2)
     rexml (3.4.1)
     rspec-core (3.13.3)
       rspec-support (~> 3.13.0)
@@ -257,6 +296,8 @@ GEM
       rubocop-rails
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
+    shoulda-matchers (6.4.0)
+      activesupport (>= 5.2.0)
     stringio (3.1.2)
     thor (1.3.2)
     timeout (0.4.3)
@@ -268,6 +309,8 @@ GEM
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
     useragent (0.16.11)
+    warden (1.2.9)
+      rack (>= 2.0.9)
     webmock (3.25.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -283,9 +326,15 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10.15)
   bootsnap
   brakeman
   debug
+  devise (~> 4.9, >= 4.9.4)
+  devise_token_auth (~> 1.2, >= 1.2.5)
+  factory_bot_rails (~> 6.4, >= 6.4.4)
+  faker (~> 3.5, >= 3.5.1)
+  omniauth (~> 2.1, >= 2.1.2)
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.1)
@@ -294,6 +343,7 @@ DEPENDENCIES
   rswag-specs
   rswag-ui
   rubocop-rails-omakase
+  shoulda-matchers (~> 6.4)
   tzinfo-data
   webmock (~> 3.25)
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,43 @@
 class ApplicationController < ActionController::API
+  # Validations
+  before_action :authenticate_user_by_token
+
+  # Error handlers
+  rescue_from ActionController::ParameterMissing, with: :parameter_missing
+  rescue_from StandardError, with: :handle_standard_error
+
+  private
+
+  def handle_standard_error(exception)
+    render json: { error: exception.message }, status: :unprocessable_entity
+  end
+
+  def parameter_missing(exception)
+    render json: { error: exception.message }, status: :bad_request
+  end
+
+  def authenticate_user_by_token
+    token = bearer_token
+    return render_unauthorized("Auth token is required") if token.blank?
+
+    auth_token = AuthToken.find_by(token: token)
+    return render_unauthorized("Invalid or expired token") if auth_token.blank? || token_expired?(auth_token)
+
+    @current_user = auth_token.user
+  end
+
+  def bearer_token
+    auth_header = request.headers["Authorization"]
+    return nil unless auth_header.present? && auth_header.start_with?("Bearer ")
+
+    auth_header.split(" ").last
+  end
+
+  def token_expired?(auth_token)
+    auth_token.expires_at < Time.current
+  end
+
+  def render_unauthorized(message)
+    render json: { error: message }, status: :unauthorized and return
+  end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,22 @@
+class RegistrationsController < ApplicationController
+  skip_before_action :authenticate_user_by_token, only: [ :create ]
+
+  def create
+    user = User.new(user_params)
+
+    if user.save
+      auth_token_service = AuthTokenService.new(user).generate_tokens
+      user.current_auth_token = auth_token_service
+
+      render json: CreatedUserSerializer.new(user).as_json, status: :created
+    else
+      render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation)
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,23 @@
+class SessionsController < ApplicationController
+  skip_before_action :authenticate_user_by_token, only: [:create]
+
+  def create
+    user = User.find_by(email: login_params[:email])
+
+    if user && user.valid_password?(login_params[:password])
+      auth_token = AuthTokenService.new(user).generate_tokens
+      user.current_auth_token = auth_token
+
+      render json: CreatedUserSerializer.new(user).as_json, status: :ok
+    else
+      render json: { error: "Invalid email or password" }, status: :unauthorized
+    end
+  end
+
+  private
+
+  def login_params
+    params.permit(:email, :password)
+  end
+end
+  

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -1,0 +1,8 @@
+class AuthToken < ApplicationRecord
+  # Associations
+  belongs_to :user
+
+  # Validations
+  validates :token, presence: true, uniqueness: true
+  validates :refresh_token, presence: true, uniqueness: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,16 @@
+class User < ApplicationRecord
+  # Default device modules
+  devise :database_authenticatable, :registerable, :validatable
+
+  # Associations
+  has_many :auth_tokens, dependent: :destroy
+
+  # Attributes
+  attr_accessor :login
+
+  # Virtual accessor to store the current auth token when create a new one
+  attr_accessor :current_auth_token
+
+  # Validations
+  validates :first_name, :last_name, :email, presence: true
+end

--- a/app/serializers/auth_token_serializer.rb
+++ b/app/serializers/auth_token_serializer.rb
@@ -1,0 +1,3 @@
+class AuthTokenSerializer < ActiveModel::Serializer
+  attributes :token, :refresh_token, :expires_at, :refresh_token_expires_at
+end

--- a/app/serializers/created_user_serializer.rb
+++ b/app/serializers/created_user_serializer.rb
@@ -1,0 +1,11 @@
+class CreatedUserSerializer < ActiveModel::Serializer
+  attributes :first_name, :last_name, :email
+
+  # Relation with AuthTokenSerializer
+  has_one :auth_token, serializer: AuthTokenSerializer
+
+  # Accessor to get the current auth token
+  def auth_token
+    object.current_auth_token
+  end
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,3 @@
+class UserSerializer < ActiveModel::Serializer
+  attributes :first_name, :last_name, :email
+end

--- a/app/services/auth_token_service.rb
+++ b/app/services/auth_token_service.rb
@@ -1,0 +1,22 @@
+class AuthTokenService
+  def initialize(user)
+    @user = user
+  end
+
+  def generate_tokens
+    raise "User does not exist" unless valid_user?
+
+    @user.auth_tokens.create(
+      token: SecureRandom.hex,
+      refresh_token: SecureRandom.hex,
+      expires_at: 1.day.from_now,
+      refresh_token_expires_at: 1.week.from_now
+    )
+  end
+
+  private
+
+  def valid_user?
+    @user.present?
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,313 @@
+# frozen_string_literal: true
+
+# Assuming you have not yet modified this file, each configuration option below
+# is set to its default value. Note that some are commented out while others
+# are not: uncommented lines are intended to protect your configuration from
+# breaking changes in upgrades (i.e., in the event that future versions of
+# Devise change the default values for those options).
+#
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # Devise will use the `secret_key_base` as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # config.secret_key = 'd607fbb10d546609d67309f8200c48e14255bcf47ad75552ae9fb6deb320045c72b656a2b3fe53fa931611720b0b05071c7b9362fe21056103b63b51358f2f4f'
+
+  # ==> Controller configuration
+  # Configure the parent class to the devise controllers.
+  # config.parent_controller = 'DeviseController'
+
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class
+  # with default "from" parameter.
+  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = 'Devise::Mailer'
+
+  # Configure the parent class responsible to send e-mails.
+  # config.parent_mailer = 'ActionMailer::Base'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/active_record'
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [:email]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [ :email ]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [ :email ]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication.
+  # For API-only applications to support authentication "out-of-the-box", you will likely want to
+  # enable this with :database unless you are using a custom strategy.
+  # The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # config.http_authenticatable = false
+
+  # If 401 status code should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  # config.http_authentication_realm = 'Application'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  # config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing skip: :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [ :http_auth ]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # When false, Devise will not attempt to reload routes on eager load.
+  # This can reduce the time taken to boot the app but if your application
+  # requires the Devise mappings to be loaded during boot time the application
+  # won't boot properly.
+  # config.reload_routes = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 12. If
+  # using other algorithms, it sets how many times you want the password to be hashed.
+  # The number of stretches used for generating the hashed password are stored
+  # with the hashed password. This allows you to change the stretches without
+  # invalidating existing passwords.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # algorithm), the cost increases exponentially with the number of stretches (e.g.
+  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+  config.stretches = Rails.env.test? ? 1 : 12
+
+  # Set up a pepper to generate the hashed password.
+  # config.pepper = '6781a932c0ed92869a33fa6f64a7ec0a46d9f8f79908cb89f72a78e3a4a10f2ee5e5e04fd92e34fc8224e6121d46af4ac6454be1c92b1e5fe7c935344de8fb17'
+
+  # Send a notification to the original email when the user's email is changed.
+  # config.send_email_changed_notification = false
+
+  # Send a notification email when the user's password is changed.
+  # config.send_password_change_notification = false
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day.
+  # You can also set it to nil, which will allow the user to access the website
+  # without confirming their account.
+  # Default is 0.days, meaning the user cannot access the website without
+  # confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [:email]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # secure: true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 6..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [:email]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = true
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [:email]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # When set to false, does not sign a user in automatically after their password is
+  # reset. Defaults to true, so a user is signed in automatically after a reset.
+  # config.sign_in_after_reset_password = true
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another hashing or encryption algorithm besides bcrypt (default).
+  # You can use :sha1, :sha512 or algorithms from others authentication tools as
+  # :clearance_sha1, :authlogic_sha512 (then you should set stretches above to 20
+  # for default behavior) and :restful_authentication_sha1 (then you should set
+  # stretches to 10, and copy REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = false
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html, :turbo_stream]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using OmniAuth, Devise cannot automatically set OmniAuth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+
+  # ==> Hotwire/Turbo configuration
+  # When using Devise with Hotwire/Turbo, the http status for error responses
+  # and some redirects must match the following. The default in Devise for existing
+  # apps is `200 OK` and `302 Found` respectively, but new apps are generated with
+  # these new defaults that match Hotwire/Turbo behavior.
+  # Note: These might become the new default in future versions of Devise.
+  config.responder.error_status = :unprocessable_entity
+  config.responder.redirect_status = :see_other
+
+  # ==> Configuration for :registerable
+
+  # When set to false, does not sign a user in automatically after their password is
+  # changed. Defaults to true, so a user is signed in automatically after changing a password.
+  # config.sign_in_after_change_password = true
+end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+DeviseTokenAuth.setup do |config|
+  # By default the authorization headers will change after each request. The
+  # client is responsible for keeping track of the changing tokens. Change
+  # this to false to prevent the Authorization header from changing after
+  # each request.
+  # config.change_headers_on_each_request = true
+
+  # By default, users will need to re-authenticate after 2 weeks. This setting
+  # determines how long tokens will remain valid after they are issued.
+  # config.token_lifespan = 2.weeks
+
+  # Limiting the token_cost to just 4 in testing will increase the performance of
+  # your test suite dramatically. The possible cost value is within range from 4
+  # to 31. It is recommended to not use a value more than 10 in other environments.
+  config.token_cost = Rails.env.test? ? 4 : 10
+
+  # Sets the max number of concurrent devices per user, which is 10 by default.
+  # After this limit is reached, the oldest tokens will be removed.
+  # config.max_number_of_devices = 10
+
+  # Sometimes it's necessary to make several requests to the API at the same
+  # time. In this case, each request in the batch will need to share the same
+  # auth token. This setting determines how far apart the requests can be while
+  # still using the same auth token.
+  # config.batch_request_buffer_throttle = 5.seconds
+
+  # This route will be the prefix for all oauth2 redirect callbacks. For
+  # example, using the default '/omniauth', the github oauth2 provider will
+  # redirect successful authentications to '/omniauth/github/callback'
+  # config.omniauth_prefix = "/omniauth"
+
+  # By default sending current password is not needed for the password update.
+  # Uncomment to enforce current_password param to be checked before all
+  # attribute updates. Set it to :password if you want it to be checked only if
+  # password is updated.
+  # config.check_current_password_before_update = :attributes
+
+  # By default we will use callbacks for single omniauth.
+  # It depends on fields like email, provider and uid.
+  # config.default_callbacks = true
+
+  # Makes it possible to change the headers names
+  # config.headers_names = {
+  #   :'authorization' => 'Authorization',
+  #   :'access-token' => 'access-token',
+  #   :'client' => 'client',
+  #   :'expiry' => 'expiry',
+  #   :'uid' => 'uid',
+  #   :'token-type' => 'token-type'
+  # }
+
+  # Makes it possible to use custom uid column
+  # config.other_uid = "foo"
+
+  # By default, only Bearer Token authentication is implemented out of the box.
+  # If, however, you wish to integrate with legacy Devise authentication, you can
+  # do so by enabling this flag. NOTE: This feature is highly experimental!
+  # config.enable_standard_devise_support = false
+
+  # By default DeviseTokenAuth will not send confirmation email, even when including
+  # devise confirmable module. If you want to use devise confirmable module and
+  # send email, set it to true. (This is a setting for compatibility)
+  # config.send_confirmation_email = true
+end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,0 +1,65 @@
+# Additional translations at https://github.com/heartcombo/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,6 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
   resources :prices, only: [ :index ]
+  post 'signup', to: 'registrations#create'
+  post 'login',  to: 'sessions#create'
 end

--- a/db/migrate/20250216192058_devise_create_users.rb
+++ b/db/migrate/20250216192058_devise_create_users.rb
@@ -1,0 +1,14 @@
+class DeviseCreateUsers < ActiveRecord::Migration[7.2]
+  def change
+    create_table :users do |t|
+      t.string :first_name
+      t.string :last_name
+      t.string :email, null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      t.timestamps
+    end
+
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/migrate/20250216193507_create_auth_tokens.rb
+++ b/db/migrate/20250216193507_create_auth_tokens.rb
@@ -1,0 +1,16 @@
+class CreateAuthTokens < ActiveRecord::Migration[7.2]
+  def change
+    create_table :auth_tokens do |t|
+      t.references :user, foreign_key: true
+      t.string :token
+      t.string :refresh_token
+      t.datetime :expires_at
+      t.datetime :refresh_token_expires_at
+
+      t.timestamps
+    end
+
+    add_index :auth_tokens, :token, unique: true
+    add_index :auth_tokens, :refresh_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,32 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 0) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_16_193507) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "auth_tokens", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "token"
+    t.string "refresh_token"
+    t.datetime "expires_at"
+    t.datetime "refresh_token_expires_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["refresh_token"], name: "index_auth_tokens_on_refresh_token", unique: true
+    t.index ["token"], name: "index_auth_tokens_on_token", unique: true
+    t.index ["user_id"], name: "index_auth_tokens_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "first_name"
+    t.string "last_name"
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+  add_foreign_key "auth_tokens", "users"
 end

--- a/spec/controllers/registration_controller_spec.rb
+++ b/spec/controllers/registration_controller_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe AuthTokenService, type: :service do
+  describe "#generate_tokens" do
+    context "when given a valid user" do
+      let(:user) { create(:user) }
+      subject { described_class.new(user) }
+
+      it "creates a new auth token" do
+        expect { subject.generate_tokens }.to change { user.auth_tokens.count }.by(1)
+      end
+
+      it "returns a valid auth token with required attributes" do
+        auth_token = subject.generate_tokens
+
+        expect(auth_token).to be_a(AuthToken)
+        expect(auth_token.token).to be_present
+        expect(auth_token.refresh_token).to be_present
+        expect(auth_token.expires_at).to be > Time.current
+        expect(auth_token.refresh_token_expires_at).to be > Time.current
+      end
+    end
+
+    context "when given an invalid user" do
+      subject { described_class.new(nil) }
+
+      it "raises an error indicating the user does not exist" do
+        expect { subject.generate_tokens }.to raise_error("User does not exist")
+      end
+    end
+  end
+end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe SessionsController, type: :controller do
+  describe "POST #create" do
+    let(:default_password) { "12345678" }
+    let!(:user) { create(:user, password: default_password, password_confirmation: default_password) }
+
+    let(:valid_params) { { email: user.email, password: default_password } }
+    let(:invalid_params) { { email: user.email, password: "WrongPassword" } }
+
+    let(:fake_token) do
+      user.auth_tokens.create!(
+        token: "fake_token_123",
+        refresh_token: "fake_refresh_123",
+        expires_at: 1.day.from_now,
+        refresh_token_expires_at: 1.week.from_now
+      )
+    end
+
+    before do
+      allow_any_instance_of(AuthTokenService).to receive(:generate_tokens).and_return(fake_token)
+    end
+
+    context "with valid credentials" do
+      it "returns status ok and the created user with token" do
+        post :create, params: valid_params, as: :json
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json["first_name"]).to eq(user.first_name)
+        expect(json["last_name"]).to eq(user.last_name)
+        expect(json["email"]).to eq(user.email)
+        expect(json["auth_token"]).to be_present
+        expect(json["auth_token"]["token"]).to eq("fake_token_123")
+      end
+    end
+
+    context "with invalid credentials" do
+      it "returns unauthorized status and error message" do
+        post :create, params: invalid_params, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+        json = JSON.parse(response.body)
+        expect(json["error"]).to eq("Invalid email or password")
+      end
+    end
+  end
+end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :user do
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+    email { Faker::Internet.email }
+    password { "password" }
+    password_confirmation { "password" }
+  end
+end

--- a/spec/integration/registrations_spec.rb
+++ b/spec/integration/registrations_spec.rb
@@ -1,0 +1,95 @@
+require 'swagger_helper'
+
+RSpec.describe 'Registrations API', type: :request, swagger_doc: 'v1/swagger.yaml' do
+  path '/signup' do
+    post 'Register a new user' do
+      tags 'Authentication'
+      consumes 'application/json'
+      produces 'application/json'
+
+      parameter name: :user, in: :body, schema: {
+        type: :object,
+        properties: {
+          user: {
+            type: :object,
+            properties: {
+              first_name: { type: :string, example: 'John' },
+              last_name: { type: :string, example: 'Doe' },
+              email: { type: :string, format: :email, example: 'john.doe@example.com' },
+              password: { type: :string, example: 'password' },
+              password_confirmation: { type: :string, example: 'password' }
+            },
+            required: %w[first_name last_name email password password_confirmation]
+          }
+        },
+        required: ['user']
+      }
+
+      response '201', 'User created' do
+        schema type: :object,
+          properties: {
+            first_name: { type: :string, example: 'John' },
+            last_name: { type: :string, example: 'Doe' },
+            email: { type: :string, format: :email, example: 'john.doe@example.com' },
+            auth_token: {
+              type: :object,
+              properties: {
+                token: { type: :string, example: 'abcdef123456' },
+                refresh_token: { type: :string, example: 'ghijkl789012' },
+                expires_at: { type: :string, format: 'date-time', example: '2025-02-18T00:01:42.969Z' },
+                refresh_token_expires_at: { type: :string, format: 'date-time', example: '2025-02-25T00:01:42.969Z' }
+              },
+              required: %w[token refresh_token expires_at refresh_token_expires_at]
+            }
+          },
+          required: %w[first_name last_name email auth_token]
+
+        let(:user) do
+          {
+            user: {
+              first_name: 'John',
+              last_name: 'Doe',
+              email: 'john.doe@example.com',
+              password: 'password',
+              password_confirmation: 'password'
+            }
+          }
+        end
+
+        run_test!
+      end
+
+      response '422', 'Unprocessable Entity' do
+        schema type: :object,
+          properties: {
+            errors: { type: :array, items: { type: :string } }
+          },
+          required: ['errors']
+        examples 'application/json' => {
+          blank: {
+            summary: 'Blank fields error',
+            value: { errors: ["Email can't be blank"] }
+          },
+          taken: {
+            summary: 'Email already taken error',
+            value: { errors: ["Email has already been taken"] }
+          }
+        }
+
+        let(:user) do
+          {
+            user: {
+              first_name: '',
+              last_name: '',
+              email: '',
+              password: '',
+              password_confirmation: ''
+            }
+          }
+        end
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/integration/sessions_spec.rb
+++ b/spec/integration/sessions_spec.rb
@@ -1,0 +1,67 @@
+require 'swagger_helper'
+
+RSpec.describe 'Sessions API', type: :request, swagger_doc: 'v1/swagger.yaml' do
+  path '/login' do
+    post 'Create a session' do
+      tags 'Sessions'
+      consumes 'application/json'
+      produces 'application/json'
+      
+      parameter name: :credentials, in: :body, schema: {
+        type: :object,
+        properties: {
+          email: { type: :string },
+          password: { type: :string }
+        },
+        required: ['email', 'password']
+      }
+
+      response '200', 'User logged in successfully' do
+        schema type: :object,
+          properties: {
+            first_name: { type: :string },
+            last_name: { type: :string },
+            email: { type: :string },
+            auth_token: {
+              type: :object,
+              properties: {
+                token: { type: :string },
+                refresh_token: { type: :string },
+                expires_at: { type: :string, format: 'date-time' },
+                refresh_token_expires_at: { type: :string, format: 'date-time' }
+              }
+            }
+          },
+          required: ['first_name', 'last_name', 'email', 'auth_token']
+
+        let(:credentials) { { email: 'juan@example.com', password: 'Password1!' } }
+        before do
+          User.create!(
+            first_name: "Juan",
+            last_name: "Pérez",
+            email: "juan@example.com",
+            password: "Password1!",
+            password_confirmation: "Password1!"
+          )
+        end
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['auth_token']).to be_present
+          expect(data['auth_token']['token']).to be_a(String)
+        end
+      end
+
+      response '401', 'Invalid credentials' do
+        schema type: :object,
+          properties: {
+            error: { type: :string }
+          },
+          required: ['error']
+
+        let(:credentials) { { email: 'juan@example.com', password: 'WrongPassword' } }
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/models/auth_token_spec.rb
+++ b/spec/models/auth_token_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe AuthToken, type: :model do
+  let(:user) { create(:user) }
+
+  subject do
+    AuthToken.new(
+      token: SecureRandom.hex,
+      refresh_token: SecureRandom.hex,
+      user: user
+    )
+  end
+
+  describe "Validations" do
+    it "is valid with all required attributes" do
+      expect(subject).to be_valid
+    end
+
+    it "ensures unique token" do
+      subject.save!
+      another_auth_token = AuthToken.new(
+        token: subject.token,
+        refresh_token: SecureRandom.hex,
+        user: user
+      )
+      expect(another_auth_token).not_to be_valid
+      expect(another_auth_token.errors[:token]).to include("has already been taken")
+    end
+
+    it "ensures unique refresh token" do
+      subject.save!
+      another_auth_token = AuthToken.new(
+        token: SecureRandom.hex,
+        refresh_token: subject.refresh_token,
+        user: user
+      )
+      expect(another_auth_token).not_to be_valid
+      expect(another_auth_token.errors[:refresh_token]).to include("has already been taken")
+    end
+
+    context 'without required attributes' do
+        it "invalid without token" do
+          subject.token = nil
+          expect(subject).not_to be_valid
+          expect(subject.errors[:token]).to include("can't be blank")
+        end
+    
+        it "invalid without refresh token" do
+          subject.refresh_token = nil
+          expect(subject).not_to be_valid
+          expect(subject.errors[:refresh_token]).to include("can't be blank")
+        end
+    end
+  end
+
+  describe "Associations" do
+    it { should belong_to(:user) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  subject do
+    User.new(
+      first_name: Faker::Name.first_name,
+      last_name: Faker::Name.last_name,
+      email: Faker::Internet.email,
+      password: "password",
+      password_confirmation: "password"
+    )
+  end
+
+  describe "Validations" do
+    it "is valid with all required attributes" do
+      expect(subject).to be_valid
+    end
+
+    context 'without required attributes' do
+      it "first_name" do
+        subject.first_name = nil
+        expect(subject).not_to be_valid
+        expect(subject.errors[:first_name]).to include("can't be blank")
+      end
+
+      it "last_name" do
+        subject.last_name = nil
+        expect(subject).not_to be_valid
+        expect(subject.errors[:last_name]).to include("can't be blank")
+      end
+
+      it "no es válido sin email" do
+        subject.email = nil
+        expect(subject).not_to be_valid
+        expect(subject.errors[:email]).to include("can't be blank")
+      end
+    end
+  end
+
+  describe "Associations" do
+    it { should have_many(:auth_tokens).dependent(:destroy) }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,6 +44,7 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
+  config.include FactoryBot::Syntax::Methods
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 
@@ -68,4 +69,12 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+end
+
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
 end

--- a/spec/services/auth_token_service_spec.rb
+++ b/spec/services/auth_token_service_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe RegistrationsController, type: :controller do
+  describe "POST #create" do
+    context "with valid parameters" do
+      let(:valid_attributes) do
+        {
+          user: {
+            first_name: Faker::Name.first_name,
+            last_name: Faker::Name.last_name,
+            email: Faker::Internet.unique.email,
+            password: "password",
+            password_confirmation: "password"
+          }
+        }
+      end
+
+      it "creates a new user and returns a created status" do
+        expect {
+          post :create, params: valid_attributes
+        }.to change(User, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+
+        json = JSON.parse(response.body)
+        expect(json).to have_key("first_name")
+        expect(json).to have_key("auth_token")
+      end
+    end
+
+    context "with invalid parameters" do
+      let(:invalid_attributes) do
+        {
+          user: {
+            first_name: "",
+            last_name: "",
+            email: "",
+            password: "",
+            password_confirmation: ""
+          }
+        }
+      end
+
+      it "does not create a new user and returns an unprocessable entity status" do
+        expect {
+          post :create, params: invalid_attributes
+        }.not_to change(User, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+
+        json = JSON.parse(response.body)
+        expect(json).to have_key("errors")
+      end
+    end
+  end
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -52,6 +52,178 @@ paths:
                 required:
                 - error
                 - code
+  "/signup":
+    post:
+      summary: Register a new user
+      tags:
+      - Authentication
+      parameters: []
+      responses:
+        '201':
+          description: User created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  first_name:
+                    type: string
+                    example: John
+                  last_name:
+                    type: string
+                    example: Doe
+                  email:
+                    type: string
+                    format: email
+                    example: john.doe@example.com
+                  auth_token:
+                    type: object
+                    properties:
+                      token:
+                        type: string
+                        example: abcdef123456
+                      refresh_token:
+                        type: string
+                        example: ghijkl789012
+                      expires_at:
+                        type: string
+                        format: date-time
+                        example: '2025-02-18T00:01:42.969Z'
+                      refresh_token_expires_at:
+                        type: string
+                        format: date-time
+                        example: '2025-02-25T00:01:42.969Z'
+                    required:
+                    - token
+                    - refresh_token
+                    - expires_at
+                    - refresh_token_expires_at
+                required:
+                - first_name
+                - last_name
+                - email
+                - auth_token
+        '422':
+          description: Unprocessable Entity
+          content:
+            application/json:
+              examples:
+                example_0:
+                  value:
+                    blank:
+                      summary: Blank fields error
+                      value:
+                        errors:
+                        - Email can't be blank
+                    taken:
+                      summary: Email already taken error
+                      value:
+                        errors:
+                        - Email has already been taken
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: string
+                required:
+                - errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user:
+                  type: object
+                  properties:
+                    first_name:
+                      type: string
+                      example: John
+                    last_name:
+                      type: string
+                      example: Doe
+                    email:
+                      type: string
+                      format: email
+                      example: john.doe@example.com
+                    password:
+                      type: string
+                      example: password
+                    password_confirmation:
+                      type: string
+                      example: password
+                  required:
+                  - first_name
+                  - last_name
+                  - email
+                  - password
+                  - password_confirmation
+              required:
+              - user
+  "/login":
+    post:
+      summary: Create a session
+      tags:
+      - Sessions
+      parameters: []
+      responses:
+        '200':
+          description: User logged in successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  first_name:
+                    type: string
+                  last_name:
+                    type: string
+                  email:
+                    type: string
+                  auth_token:
+                    type: object
+                    properties:
+                      token:
+                        type: string
+                      refresh_token:
+                        type: string
+                      expires_at:
+                        type: string
+                        format: date-time
+                      refresh_token_expires_at:
+                        type: string
+                        format: date-time
+                required:
+                - first_name
+                - last_name
+                - email
+                - auth_token
+        '401':
+          description: Invalid credentials
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                required:
+                - error
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+              required:
+              - email
+              - password
 servers:
 - url: http://localhost:3000
 - url: https://mr-peanutbutter-app-35d05975bacd.herokuapp.com/


### PR DESCRIPTION
### Changelog

This PR includes 2 new tables to manage user and auth tokens, including:

- 2 new migrations to create tables `users` and `auth_tokens`
- 2 new models `User` and `AuthToken`
- 2 new serializers `UserSerializer` and `AuthTokenSerializer`
- Integration with device
- Integration with `Faker` and `Factory` for testing


### Migration plan

- To run migration you can execute `rails db:migrate version=20250216193507`

### Rollback plan

- To rollback migration you can execute `rails db:migrate version=20250216192058`