### PR TITLE
Signup user logic

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,43 @@
 class ApplicationController < ActionController::API
+  # Validations
+  before_action :authenticate_user_by_token
+
+  # Error handlers
+  rescue_from ActionController::ParameterMissing, with: :parameter_missing
+  rescue_from StandardError, with: :handle_standard_error
+
+  private
+
+  def handle_standard_error(exception)
+    render json: { error: exception.message }, status: :unprocessable_entity
+  end
+
+  def parameter_missing(exception)
+    render json: { error: exception.message }, status: :bad_request
+  end
+
+  def authenticate_user_by_token
+    token = bearer_token
+    return render_unauthorized("Auth token is required") if token.blank?
+
+    auth_token = AuthToken.find_by(token: token)
+    return render_unauthorized("Invalid or expired token") if auth_token.blank? || token_expired?(auth_token)
+
+    @current_user = auth_token.user
+  end
+
+  def bearer_token
+    auth_header = request.headers["Authorization"]
+    return nil unless auth_header.present? && auth_header.start_with?("Bearer ")
+
+    auth_header.split(" ").last
+  end
+
+  def token_expired?(auth_token)
+    auth_token.expires_at < Time.current
+  end
+
+  def render_unauthorized(message)
+    render json: { error: message }, status: :unauthorized and return
+  end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,22 @@
+class RegistrationsController < ApplicationController
+  skip_before_action :authenticate_user_by_token, only: [ :create ]
+
+  def create
+    user = User.new(user_params)
+
+    if user.save
+      auth_token_service = AuthTokenService.new(user).generate_tokens
+      user.current_auth_token = auth_token_service
+
+      render json: CreatedUserSerializer.new(user).as_json, status: :created
+    else
+      render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation)
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,23 @@
+class SessionsController < ApplicationController
+  skip_before_action :authenticate_user_by_token, only: [:create]
+
+  def create
+    user = User.find_by(email: login_params[:email])
+
+    if user && user.valid_password?(login_params[:password])
+      auth_token = AuthTokenService.new(user).generate_tokens
+      user.current_auth_token = auth_token
+
+      render json: CreatedUserSerializer.new(user).as_json, status: :ok
+    else
+      render json: { error: "Invalid email or password" }, status: :unauthorized
+    end
+  end
+
+  private
+
+  def login_params
+    params.permit(:email, :password)
+  end
+end
+  

--- a/app/serializers/created_user_serializer.rb
+++ b/app/serializers/created_user_serializer.rb
@@ -1,0 +1,11 @@
+class CreatedUserSerializer < ActiveModel::Serializer
+  attributes :first_name, :last_name, :email
+
+  # Relation with AuthTokenSerializer
+  has_one :auth_token, serializer: AuthTokenSerializer
+
+  # Accessor to get the current auth token
+  def auth_token
+    object.current_auth_token
+  end
+end

--- a/app/services/auth_token_service.rb
+++ b/app/services/auth_token_service.rb
@@ -1,0 +1,22 @@
+class AuthTokenService
+  def initialize(user)
+    @user = user
+  end
+
+  def generate_tokens
+    raise "User does not exist" unless valid_user?
+
+    @user.auth_tokens.create(
+      token: SecureRandom.hex,
+      refresh_token: SecureRandom.hex,
+      expires_at: 1.day.from_now,
+      refresh_token_expires_at: 1.week.from_now
+    )
+  end
+
+  private
+
+  def valid_user?
+    @user.present?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
   resources :prices, only: [ :index ]
+  post 'signup', to: 'registrations#create'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,5 @@ Rails.application.routes.draw do
 
   resources :prices, only: [ :index ]
   post 'signup', to: 'registrations#create'
+  post 'login',  to: 'sessions#create'
 end

--- a/spec/controllers/registration_controller_spec.rb
+++ b/spec/controllers/registration_controller_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe AuthTokenService, type: :service do
+  describe "#generate_tokens" do
+    context "when given a valid user" do
+      let(:user) { create(:user) }
+      subject { described_class.new(user) }
+
+      it "creates a new auth token" do
+        expect { subject.generate_tokens }.to change { user.auth_tokens.count }.by(1)
+      end
+
+      it "returns a valid auth token with required attributes" do
+        auth_token = subject.generate_tokens
+
+        expect(auth_token).to be_a(AuthToken)
+        expect(auth_token.token).to be_present
+        expect(auth_token.refresh_token).to be_present
+        expect(auth_token.expires_at).to be > Time.current
+        expect(auth_token.refresh_token_expires_at).to be > Time.current
+      end
+    end
+
+    context "when given an invalid user" do
+      subject { described_class.new(nil) }
+
+      it "raises an error indicating the user does not exist" do
+        expect { subject.generate_tokens }.to raise_error("User does not exist")
+      end
+    end
+  end
+end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe SessionsController, type: :controller do
+  describe "POST #create" do
+    let(:default_password) { "12345678" }
+    let!(:user) { create(:user, password: default_password, password_confirmation: default_password) }
+
+    let(:valid_params) { { email: user.email, password: default_password } }
+    let(:invalid_params) { { email: user.email, password: "WrongPassword" } }
+
+    let(:fake_token) do
+      user.auth_tokens.create!(
+        token: "fake_token_123",
+        refresh_token: "fake_refresh_123",
+        expires_at: 1.day.from_now,
+        refresh_token_expires_at: 1.week.from_now
+      )
+    end
+
+    before do
+      allow_any_instance_of(AuthTokenService).to receive(:generate_tokens).and_return(fake_token)
+    end
+
+    context "with valid credentials" do
+      it "returns status ok and the created user with token" do
+        post :create, params: valid_params, as: :json
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json["first_name"]).to eq(user.first_name)
+        expect(json["last_name"]).to eq(user.last_name)
+        expect(json["email"]).to eq(user.email)
+        expect(json["auth_token"]).to be_present
+        expect(json["auth_token"]["token"]).to eq("fake_token_123")
+      end
+    end
+
+    context "with invalid credentials" do
+      it "returns unauthorized status and error message" do
+        post :create, params: invalid_params, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+        json = JSON.parse(response.body)
+        expect(json["error"]).to eq("Invalid email or password")
+      end
+    end
+  end
+end

--- a/spec/integration/registrations_spec.rb
+++ b/spec/integration/registrations_spec.rb
@@ -1,0 +1,95 @@
+require 'swagger_helper'
+
+RSpec.describe 'Registrations API', type: :request, swagger_doc: 'v1/swagger.yaml' do
+  path '/signup' do
+    post 'Register a new user' do
+      tags 'Authentication'
+      consumes 'application/json'
+      produces 'application/json'
+
+      parameter name: :user, in: :body, schema: {
+        type: :object,
+        properties: {
+          user: {
+            type: :object,
+            properties: {
+              first_name: { type: :string, example: 'John' },
+              last_name: { type: :string, example: 'Doe' },
+              email: { type: :string, format: :email, example: 'john.doe@example.com' },
+              password: { type: :string, example: 'password' },
+              password_confirmation: { type: :string, example: 'password' }
+            },
+            required: %w[first_name last_name email password password_confirmation]
+          }
+        },
+        required: ['user']
+      }
+
+      response '201', 'User created' do
+        schema type: :object,
+          properties: {
+            first_name: { type: :string, example: 'John' },
+            last_name: { type: :string, example: 'Doe' },
+            email: { type: :string, format: :email, example: 'john.doe@example.com' },
+            auth_token: {
+              type: :object,
+              properties: {
+                token: { type: :string, example: 'abcdef123456' },
+                refresh_token: { type: :string, example: 'ghijkl789012' },
+                expires_at: { type: :string, format: 'date-time', example: '2025-02-18T00:01:42.969Z' },
+                refresh_token_expires_at: { type: :string, format: 'date-time', example: '2025-02-25T00:01:42.969Z' }
+              },
+              required: %w[token refresh_token expires_at refresh_token_expires_at]
+            }
+          },
+          required: %w[first_name last_name email auth_token]
+
+        let(:user) do
+          {
+            user: {
+              first_name: 'John',
+              last_name: 'Doe',
+              email: 'john.doe@example.com',
+              password: 'password',
+              password_confirmation: 'password'
+            }
+          }
+        end
+
+        run_test!
+      end
+
+      response '422', 'Unprocessable Entity' do
+        schema type: :object,
+          properties: {
+            errors: { type: :array, items: { type: :string } }
+          },
+          required: ['errors']
+        examples 'application/json' => {
+          blank: {
+            summary: 'Blank fields error',
+            value: { errors: ["Email can't be blank"] }
+          },
+          taken: {
+            summary: 'Email already taken error',
+            value: { errors: ["Email has already been taken"] }
+          }
+        }
+
+        let(:user) do
+          {
+            user: {
+              first_name: '',
+              last_name: '',
+              email: '',
+              password: '',
+              password_confirmation: ''
+            }
+          }
+        end
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/integration/sessions_spec.rb
+++ b/spec/integration/sessions_spec.rb
@@ -1,0 +1,67 @@
+require 'swagger_helper'
+
+RSpec.describe 'Sessions API', type: :request, swagger_doc: 'v1/swagger.yaml' do
+  path '/login' do
+    post 'Create a session' do
+      tags 'Sessions'
+      consumes 'application/json'
+      produces 'application/json'
+      
+      parameter name: :credentials, in: :body, schema: {
+        type: :object,
+        properties: {
+          email: { type: :string },
+          password: { type: :string }
+        },
+        required: ['email', 'password']
+      }
+
+      response '200', 'User logged in successfully' do
+        schema type: :object,
+          properties: {
+            first_name: { type: :string },
+            last_name: { type: :string },
+            email: { type: :string },
+            auth_token: {
+              type: :object,
+              properties: {
+                token: { type: :string },
+                refresh_token: { type: :string },
+                expires_at: { type: :string, format: 'date-time' },
+                refresh_token_expires_at: { type: :string, format: 'date-time' }
+              }
+            }
+          },
+          required: ['first_name', 'last_name', 'email', 'auth_token']
+
+        let(:credentials) { { email: 'juan@example.com', password: 'Password1!' } }
+        before do
+          User.create!(
+            first_name: "Juan",
+            last_name: "Pérez",
+            email: "juan@example.com",
+            password: "Password1!",
+            password_confirmation: "Password1!"
+          )
+        end
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['auth_token']).to be_present
+          expect(data['auth_token']['token']).to be_a(String)
+        end
+      end
+
+      response '401', 'Invalid credentials' do
+        schema type: :object,
+          properties: {
+            error: { type: :string }
+          },
+          required: ['error']
+
+        let(:credentials) { { email: 'juan@example.com', password: 'WrongPassword' } }
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/services/auth_token_service_spec.rb
+++ b/spec/services/auth_token_service_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe RegistrationsController, type: :controller do
+  describe "POST #create" do
+    context "with valid parameters" do
+      let(:valid_attributes) do
+        {
+          user: {
+            first_name: Faker::Name.first_name,
+            last_name: Faker::Name.last_name,
+            email: Faker::Internet.unique.email,
+            password: "password",
+            password_confirmation: "password"
+          }
+        }
+      end
+
+      it "creates a new user and returns a created status" do
+        expect {
+          post :create, params: valid_attributes
+        }.to change(User, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+
+        json = JSON.parse(response.body)
+        expect(json).to have_key("first_name")
+        expect(json).to have_key("auth_token")
+      end
+    end
+
+    context "with invalid parameters" do
+      let(:invalid_attributes) do
+        {
+          user: {
+            first_name: "",
+            last_name: "",
+            email: "",
+            password: "",
+            password_confirmation: ""
+          }
+        }
+      end
+
+      it "does not create a new user and returns an unprocessable entity status" do
+        expect {
+          post :create, params: invalid_attributes
+        }.not_to change(User, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+
+        json = JSON.parse(response.body)
+        expect(json).to have_key("errors")
+      end
+    end
+  end
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -52,6 +52,116 @@ paths:
                 required:
                 - error
                 - code
+  "/signup":
+    post:
+      summary: Register a new user
+      tags:
+      - Authentication
+      parameters: []
+      responses:
+        '201':
+          description: User created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  first_name:
+                    type: string
+                    example: John
+                  last_name:
+                    type: string
+                    example: Doe
+                  email:
+                    type: string
+                    format: email
+                    example: john.doe@example.com
+                  auth_token:
+                    type: object
+                    properties:
+                      token:
+                        type: string
+                        example: abcdef123456
+                      refresh_token:
+                        type: string
+                        example: ghijkl789012
+                      expires_at:
+                        type: string
+                        format: date-time
+                        example: '2025-02-18T00:01:42.969Z'
+                      refresh_token_expires_at:
+                        type: string
+                        format: date-time
+                        example: '2025-02-25T00:01:42.969Z'
+                    required:
+                    - token
+                    - refresh_token
+                    - expires_at
+                    - refresh_token_expires_at
+                required:
+                - first_name
+                - last_name
+                - email
+                - auth_token
+        '422':
+          description: Unprocessable Entity
+          content:
+            application/json:
+              examples:
+                example_0:
+                  value:
+                    blank:
+                      summary: Blank fields error
+                      value:
+                        errors:
+                        - Email can't be blank
+                    taken:
+                      summary: Email already taken error
+                      value:
+                        errors:
+                        - Email has already been taken
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: string
+                required:
+                - errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user:
+                  type: object
+                  properties:
+                    first_name:
+                      type: string
+                      example: John
+                    last_name:
+                      type: string
+                      example: Doe
+                    email:
+                      type: string
+                      format: email
+                      example: john.doe@example.com
+                    password:
+                      type: string
+                      example: password
+                    password_confirmation:
+                      type: string
+                      example: password
+                  required:
+                  - first_name
+                  - last_name
+                  - email
+                  - password
+                  - password_confirmation
+              required:
+              - user
 servers:
 - url: http://localhost:3000
 - url: https://mr-peanutbutter-app-35d05975bacd.herokuapp.com/

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -162,6 +162,68 @@ paths:
                   - password_confirmation
               required:
               - user
+  "/login":
+    post:
+      summary: Create a session
+      tags:
+      - Sessions
+      parameters: []
+      responses:
+        '200':
+          description: User logged in successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  first_name:
+                    type: string
+                  last_name:
+                    type: string
+                  email:
+                    type: string
+                  auth_token:
+                    type: object
+                    properties:
+                      token:
+                        type: string
+                      refresh_token:
+                        type: string
+                      expires_at:
+                        type: string
+                        format: date-time
+                      refresh_token_expires_at:
+                        type: string
+                        format: date-time
+                required:
+                - first_name
+                - last_name
+                - email
+                - auth_token
+        '401':
+          description: Invalid credentials
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                required:
+                - error
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+              required:
+              - email
+              - password
 servers:
 - url: http://localhost:3000
 - url: https://mr-peanutbutter-app-35d05975bacd.herokuapp.com/


### PR DESCRIPTION
### Changelog

This PR includes logic to create new users and their auth tokens, including:

- 1 new `POST` endpoint `signup`
- 1 new auth validator `authenticate_user_by_token` on `ApplicationController`
- 2 new errors handler on  `ApplicationController`
- 1 new controller `RegistrationsController`
- 1 new serializer `CreatedUserSerializer`
- 1 new service `AuthTokenService`