### PR TITLE
Fix Exchange and WalletExchange associations

### DIFF
--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -1,7 +1,7 @@
 class Exchange < ApplicationRecord
   # Associations
   belongs_to :user
-  has_one :wallet_exchange, dependent: :destroy
+  has_many :wallet_exchanges, dependent: :destroy
 
   # Validations
   validates :exchange_type, :amount_sent, :currency_sent, :amount_received, :currency_received, :exchange_rate, presence: true

--- a/spec/models/exchange_spec.rb
+++ b/spec/models/exchange_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Exchange, type: :model do
   describe 'associations' do
     it { should belong_to(:user) }
-    it { should have_one(:wallet_exchange) }
+    it { should have_many(:wallet_exchanges) }
   end
  
   describe 'validations' do


### PR DESCRIPTION
### Changelog

This PR fixes a relation bug of `Exchange` with `WalletExchange` allowing to have many `WalletExchange` in one `Exchange`